### PR TITLE
Add stopping rules finder and test cases

### DIFF
--- a/src/pyregularexpression/interim_analysis_stopping_rules_finder.py
+++ b/src/pyregularexpression/interim_analysis_stopping_rules_finder.py
@@ -1,5 +1,5 @@
 # In src/pyregularexpression/interim_analysis_stopping_rules_finder.py
-
+'''
 INTERIM_ANALYSIS_STOPPING_RULES_FINDERS = {
     "rule1": lambda text: "Interim analysis rule 1 applied to " + text,
     "rule2": lambda text: "Interim analysis rule 2 applied to " + text,
@@ -7,3 +7,55 @@ INTERIM_ANALYSIS_STOPPING_RULES_FINDERS = {
 }
 
 # You can expand this dictionary with more rules and their corresponding functions as per the requirements.
+
+
+interim_analysis_stopping_rules_finder.py – multi-tiered finder for interim analysis stopping rules.
+
+Variants:
+    • v1 – broad pattern match on keywords like 'interim analysis', 'DSMB', 'stopping rule'
+    • v2 – match must include statistical boundary mention (e.g. p < 0.001)
+    • v3 – tight template for planned interim analysis with named boundaries
+'''
+
+import re
+from typing import List, Tuple, Callable, Dict
+
+# ─────────────────────────────
+# 1.  Patterns
+# ─────────────────────────────
+INTERIM_ANALYSIS_RE = re.compile(r"\b(interim\s+analysis|DSMB|stopping\s+rule|stopping\s+boundar(y|ies))\b", re.I)
+STATISTICAL_BOUNDARY_RE = re.compile(r"(p\s*[<≤]\s*0\.\d+|\bO[’']Brien[-\s]?Fleming\b|\bHaybittle[-\s]?Peto\b)", re.I)
+TEMPLATE_RE = re.compile(r"(Interim analysis at \d+ (weeks|months).+?(O[’']Brien[-\s]?Fleming|Haybittle[-\s]?Peto).+?p\s*[<≤]\s*0\.\d+)", re.I)
+
+# ─────────────────────────────
+# 2.  Finders
+# ─────────────────────────────
+def find_stopping_rule_v1(text: str) -> List[Tuple[int, int, str]]:
+    """v1: Broad keyword match for interim analysis mentions."""
+    return [(m.start(), m.end(), m.group()) for m in INTERIM_ANALYSIS_RE.finditer(text)]
+
+
+def find_stopping_rule_v2(text: str) -> List[Tuple[int, int, str]]:
+    """v2: Must include both interim/stopping cue and statistical boundary."""
+    out = []
+    for m in INTERIM_ANALYSIS_RE.finditer(text):
+        span_text = text[max(0, m.start()-50):m.end()+50]
+        if STATISTICAL_BOUNDARY_RE.search(span_text):
+            out.append((m.start(), m.end(), m.group()))
+    return out
+
+
+def find_stopping_rule_v3(text: str) -> List[Tuple[int, int, str]]:
+    """v3: Match a tight template like 'Interim analysis at X months... p < 0.001'."""
+    return [(m.start(), m.end(), m.group()) for m in TEMPLATE_RE.finditer(text)]
+
+# ─────────────────────────────
+# 3.  Mapping
+# ─────────────────────────────
+INTERIM_ANALYSIS_STOPPING_RULES_FINDERS: Dict[str, Callable[[str], List[Tuple[int, int, str]]]] = {
+    "v1": find_stopping_rule_v1,
+    "v2": find_stopping_rule_v2,
+    "v3": find_stopping_rule_v3,
+}
+
+__all__ = ["find_stopping_rule_v1", "find_stopping_rule_v2", "find_stopping_rule_v3", "INTERIM_ANALYSIS_STOPPING_RULES_FINDERS"]

--- a/tests/test_interim_analysis_stopping_rules_finder.py
+++ b/tests/test_interim_analysis_stopping_rules_finder.py
@@ -1,14 +1,60 @@
-"""Smoke tests for interim_analysis_stopping_rules finder."""
-from pyregularexpression.interim_analysis_stopping_rules_finder import INTERIM_ANALYSIS_STOPPING_RULES_FINDERS
+# tests/test_interim_analysis_stopping_rules_finder.py
 
-examples = {
-    "hit_boundary": "Interim analysis at 6 months with O’Brien-Fleming boundary p < 0.001.",
-    "hit_plan": "A stopping rule for futility was specified, and the DSMB could terminate early.",
-    "miss_interim_results": "Interim results from another study suggested changes.",
-    "miss_other": "We planned final analysis after all data collected."
-}
+"""Tests for interim_analysis_stopping_rules_finder.py"""
 
-for label, txt in examples.items():
-    print(f"\n=== {label} ===\n{txt}")
-    for name, fn in INTERIM_ANALYSIS_STOPPING_RULES_FINDERS.items():
-        print(f" {name}: {fn(txt)}")
+import pytest
+from pyregularexpression.interim_analysis_stopping_rules_finder import (
+    find_stopping_rule_v1,
+    find_stopping_rule_v2,
+    find_stopping_rule_v3
+)
+
+# ─────────────────────────────
+# v1: Broad match
+# ─────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("The study included an interim analysis after 6 months.", True, "v1_pos_basic"),
+        ("A DSMB meeting was scheduled.", True, "v1_pos_dsmb"),
+        ("Final analysis was performed after all data was collected.", False, "v1_neg_no_interim"),
+        ("This analysis did not involve any early stopping.", False, "v1_neg_explicit_no_stop"),
+    ]
+)
+def test_v1(text, should_match, test_id):
+    matches = find_stopping_rule_v1(text)
+    assert bool(matches) == should_match, f"v1 failed: {test_id}"
+
+
+# ─────────────────────────────
+# v2: Keyword + boundary
+# ─────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("Interim analysis at 6 months with O’Brien-Fleming boundary p < 0.001.", True, "v2_pos_boundary"),
+        ("A stopping rule was applied using p < 0.01.", True, "v2_pos_stat_only"),
+        ("DSMB decided based on clinical judgment.", False, "v2_neg_no_stat"),
+        ("Interim analysis but no statistical criteria mentioned.", False, "v2_neg_no_boundary"),
+    ]
+)
+def test_v2(text, should_match, test_id):
+    matches = find_stopping_rule_v2(text)
+    assert bool(matches) == should_match, f"v2 failed: {test_id}"
+
+
+# ─────────────────────────────
+# v3: Tight template
+# ─────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("Interim analysis at 6 months with O’Brien-Fleming boundary p < 0.001.", True, "v3_pos_full_template"),
+        ("Interim analysis at 12 weeks using Haybittle-Peto p < 0.01.", True, "v3_pos_alt_template"),
+        ("Interim analysis with DSMB but no boundaries given.", False, "v3_neg_missing_boundary"),
+        ("Final analysis planned at study completion.", False, "v3_neg_no_interim"),
+    ]
+)
+def test_v3(text, should_match, test_id):
+    matches = find_stopping_rule_v3(text)
+    assert bool(matches) == should_match, f"v3 failed: {test_id}"


### PR DESCRIPTION
Implements a three-tiered interim analysis/stopping rules detection system (v1–v3) using regex patterns for broad keywords, statistical boundaries, and tight templates. Adds corresponding tests to validate match accuracy across tiers.