### PR TITLE
“Update exit_criterion and exclusion_rule finders”

### DIFF
--- a/src/pyregularexpression/exclusion_rule_finder.py
+++ b/src/pyregularexpression/exclusion_rule_finder.py
@@ -181,3 +181,4 @@ __all__ = [
 # handy aliases
 find_exclusion_rule_high_recall = find_exclusion_rule_v1
 find_exclusion_rule_high_precision = find_exclusion_rule_v5
+

--- a/src/pyregularexpression/exclusion_rule_finder.py
+++ b/src/pyregularexpression/exclusion_rule_finder.py
@@ -14,6 +14,7 @@ from typing import List, Tuple, Sequence, Dict, Callable
 # ─────────────────────────────
 # 0.  Shared utilities
 # ─────────────────────────────
+
 TOKEN_RE = re.compile(r"\S+")
 
 def _token_spans(text: str) -> List[Tuple[int, int]]:

--- a/src/pyregularexpression/exit_criterion_finder.py
+++ b/src/pyregularexpression/exit_criterion_finder.py
@@ -17,6 +17,7 @@ from typing import List, Tuple, Sequence, Dict, Callable
 # ─────────────────────────────
 # 0.  Shared utilities
 # ─────────────────────────────
+
 TOKEN_RE = re.compile(r"\S+")
 
 def _token_spans(text: str) -> List[Tuple[int, int]]:

--- a/src/pyregularexpression/exit_criterion_finder.py
+++ b/src/pyregularexpression/exit_criterion_finder.py
@@ -155,3 +155,4 @@ __all__ = [
 # handy aliases
 find_exit_criterion_high_recall = find_exit_criterion_v1
 find_exit_criterion_high_precision = find_exit_criterion_v5
+

--- a/tests/test_exclusion_rule_finder.py
+++ b/tests/test_exclusion_rule_finder.py
@@ -1,4 +1,5 @@
 # tests/test_exclusion_rule_finder.py
+
 """
 Complete test suite for exclusion_rule_finder.py.
 
@@ -120,3 +121,4 @@ def test_find_exclusion_rule_v4_light(text, should_match, test_id):
 def test_find_exclusion_rule_v5_light(text, should_match, test_id):
     matches = find_exclusion_rule_v5(text)
     assert bool(matches) == should_match, f"v5 failed for ID: {test_id}"
+

--- a/tests/test_exclusion_rule_finder.py
+++ b/tests/test_exclusion_rule_finder.py
@@ -122,3 +122,4 @@ def test_find_exclusion_rule_v5_light(text, should_match, test_id):
     matches = find_exclusion_rule_v5(text)
     assert bool(matches) == should_match, f"v5 failed for ID: {test_id}"
 
+

--- a/tests/test_exit_criterion_finder.py
+++ b/tests/test_exit_criterion_finder.py
@@ -18,6 +18,7 @@ from pyregularexpression.exit_criterion_finder import (
 # ────────────────────────────────────
 # Robust Tests for v1 (High Recall with trap filtering)
 # ────────────────────────────────────
+
 @pytest.mark.parametrize(
     "text, should_match, test_id",
     [

--- a/tests/test_exit_criterion_finder.py
+++ b/tests/test_exit_criterion_finder.py
@@ -111,3 +111,4 @@ def test_find_exit_criterion_v4_light(text, should_match, test_id):
 def test_find_exit_criterion_v5_light(text, should_match, test_id):
     matches = find_exit_criterion_v5(text)
     assert bool(matches) == should_match, f"v5 failed for ID: {test_id}"
+    


### PR DESCRIPTION
## Background
### Accidental merge
The regex improvements for exit_criterion_finder and exclusion_rule_finder were merged from sudeep3 into develop without a formal review PR.

### Revert on develop
We reverted that merge to restore develop to its prior state, preserving history and avoiding unintended changes.

## What this PR Does

- **Reapplies only the intended changes from sudeep3**:
- src/pyregularexpression/exit_criterion_finder.py
- tests/test_exit_criterion_finder.py
- src/pyregularexpression/exclusion_rule_finder.py
- tests/test_exclusion_rule_finder.py

**Creates fresh commits so that GitHub will display the diffs for review.
Leaves all other files untouched.**

## What to Review
**Regex logic** in both finder modules:
- Are all edge cases for “exit criterion” and “exclusion rule” correctly handled?

**Test coverage**:
- Do the new/updated tests fully exercise the revised patterns? (confirmed by Jack)



