### PR TITLE
Feature/washout period finder

### DIFF
--- a/src/pyregularexpression/washout_period_finder.py
+++ b/src/pyregularexpression/washout_period_finder.py
@@ -18,6 +18,8 @@ from typing import List, Tuple, Sequence, Dict, Callable
 # allow normal *or* non‑breaking hyphens
 HYPHEN = r"[-\u2011]"
 
+SEP = rf"(?:{HYPHEN}|\s+)"
+
 TOKEN_RE = re.compile(r"\S+")
 
 def _token_spans(text: str) -> List[Tuple[int, int]]:

--- a/src/pyregularexpression/washout_period_finder.py
+++ b/src/pyregularexpression/washout_period_finder.py
@@ -69,7 +69,7 @@ HEADING_WASHOUT_RE = re.compile(
 TRAP_RE = re.compile(r"\b(?:stopped|discontinued|due\s+to\s+side[- ]?effects|adverse\s+events?)\b", re.I)
 
 TIGHT_TEMPLATE_RE = re.compile(
-    r"(?:\d+\s*(?:month|week|year)s?\s+washout\s+(?:period\s+)?with\s+no\s+[A-Za-z\s]{1,40}|drug[- ]?free\s+for\s+\d+\s*(?:month|week|year)s?\s+before\s+index)",
+    r"(?:\d+[- ]?(?:month|week|year)s?\s+washout(?:\s+period)?\s+with\s+no\s+[a-z\s]{1,40}(?:\s+was\s+required|\s+was\s+implemented|\s+completed)?|drug[- ]?free\s+for\s+\d+[- ]?(?:month|week|year)s?\s+before\s+index)",
     re.I,
 )
 
@@ -176,7 +176,7 @@ def find_washout_period_v4(text: str, window: int = 8) -> List[Tuple[int, int, s
     return out
 
 def find_washout_period_v5(text: str) -> List[Tuple[int, int, str]]:
-    """Tier 5 – tight template with duration and drug‑free cue."""    
+    """Tier 5 – tight template with cue + duration + 'no drugs'."""
     return _collect([TIGHT_TEMPLATE_RE], text)
 
 # ─────────────────────────────

--- a/src/pyregularexpression/washout_period_finder.py
+++ b/src/pyregularexpression/washout_period_finder.py
@@ -87,6 +87,14 @@ def _collect(patterns: Sequence[re.Pattern[str]], text: str) -> List[Tuple[int, 
             out.append((w_s, w_e, m.group(0)))
     return out
 
+def _char_to_token_index_map(text: str, token_spans: List[Tuple[int,int]]) -> Dict[int,int]:
+    """Map each character position to its token index."""
+    char2tok = {}
+    for tok_i, (s,e) in enumerate(token_spans):
+        for pos in range(s, e):
+            char2tok[pos] = tok_i
+    return char2tok
+
 # ─────────────────────────────
 # 3.  Finder variants
 # ─────────────────────────────

--- a/src/pyregularexpression/washout_period_finder.py
+++ b/src/pyregularexpression/washout_period_finder.py
@@ -35,8 +35,18 @@ def _char_span_to_word_span(span: Tuple[int, int], token_spans: Sequence[Tuple[i
 # 1.  Regex assets
 # ─────────────────────────────
 WASHOUT_CUE_RE = re.compile(
-    r"\b(?:washout\s+period|washout|run[- ]?in|clearance\s+period|drug[- ]?free|treatment[- ]?free|no\s+therapy)\b",
-    re.I,
+    rf"""\b(
+        washout(?:{SEP}period)?        |   # "washout", "washout period", "washout‑period"
+        run{SEP}in                      |   # "run in", "run‑in"
+        clearance(?:{SEP}period)?      |   # "clearance", "clearance period", "clearance‑period"
+        treatment{SEP}free              |   # "treatment free", "treatment‑free"
+        drug{SEP}free                   |   # "drug free", "drug‑free"
+        no\ therapy                     |   # "no therapy"
+        no\ medications                 |   # "no medications"
+        no\ drugs                       |
+        no\ antihypertensives          # catch "No antihypertensives were used."
+    )\b""",
+    re.IGNORECASE | re.VERBOSE
 )
 
 DURATION_RE = re.compile(r"\b\d+\s*(?:day|week|month|year)s?\b", re.I)

--- a/src/pyregularexpression/washout_period_finder.py
+++ b/src/pyregularexpression/washout_period_finder.py
@@ -20,6 +20,8 @@ HYPHEN = r"[-\u2011]"
 
 SEP = rf"(?:{HYPHEN}|\s+)"
 
+NUMBER_WORD = r"(?:one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)"
+
 TOKEN_RE = re.compile(r"\S+")
 
 def _token_spans(text: str) -> List[Tuple[int, int]]:
@@ -49,11 +51,20 @@ WASHOUT_CUE_RE = re.compile(
     re.IGNORECASE | re.VERBOSE
 )
 
-DURATION_RE = re.compile(r"\b\d+\s*(?:day|week|month|year)s?\b", re.I)
+DURATION_RE = re.compile(
+    rf"\b(?:(\d+{HYPHEN}?|{NUMBER_WORD})\s*(?:day|week|month|year)s?)\b",
+    re.I
+)
 
-BEFORE_ANCHOR_RE = re.compile(r"\b(?:before|prior\s+to|preceding|pre[- ]index|pre[- ]baseline)\b", re.I)
+BEFORE_ANCHOR_RE = re.compile(r"\b(?:before|prior\s+to|preceding|pre[- ]?index|pre[- ]?baseline)\b", re.I)
 
-HEADING_WASHOUT_RE = re.compile(r"(?m)^(?:washout\s+period|run[- ]?in|clearance\s+period)\s*[:\-]?\s*$", re.I)
+HEADING_WASHOUT_RE = re.compile(
+    rf"(?im)^ *(?:" 
+       rf"washout(?:{SEP}period)|"
+       rf"run{SEP}in|"
+       rf"clearance(?:{SEP}period)"
+    r")\s*[:\-]"
+)
 
 TRAP_RE = re.compile(r"\b(?:stopped|discontinued|due\s+to\s+side[- ]?effects|adverse\s+events?)\b", re.I)
 

--- a/src/pyregularexpression/washout_period_finder.py
+++ b/src/pyregularexpression/washout_period_finder.py
@@ -1,5 +1,5 @@
-
-"""washout_period_finder.py – precision/recall ladder for *washout period* definitions.
+"""
+washout_period_finder.py – precision/recall ladder for *washout period* definitions.
 Five variants (v1‑v5):
     • v1 – high recall: any washout/run‑in/drug‑free cue
     • v2 – cue + explicit duration (months / weeks / years) or “drug‑free / treatment‑free” within ±window tokens
@@ -15,6 +15,9 @@ from typing import List, Tuple, Sequence, Dict, Callable
 # ─────────────────────────────
 # 0.  Shared utilities
 # ─────────────────────────────
+# allow normal *or* non‑breaking hyphens
+HYPHEN = r"[-\u2011]"
+
 TOKEN_RE = re.compile(r"\S+")
 
 def _token_spans(text: str) -> List[Tuple[int, int]]:

--- a/tests/test_washout_period_finder.py
+++ b/tests/test_washout_period_finder.py
@@ -1,15 +1,105 @@
+# tests/test_washout_period_finder.py
+"""
+Test suite for washout_period_finder.py
 
-"""Smoke tests for washout_period_finder variants."""
-from pyregularexpression.washout_period_finder import WASHOUT_PERIOD_FINDERS
+This suite includes high-recall tests (v1), duration+cue (v2), heading-based (v3),
+anchor-aware (v4), and strict-template (v5) tests.
+"""
 
-examples = {
-    "hit_12m": "A 12-month washout period with no antihypertensives was required before index.",
-    "hit_drug_free": "Participants were drug-free for 6 months prior to baseline.",
-    "miss_side_effect": "Patients stopped meds due to side-effects.",
-    "miss_lab_wash": "The protocol included a PBS wash step between incubations."
-}
+import pytest
+from pyregularexpression.washout_period_finder import (
+    find_washout_period_v1,
+    find_washout_period_v2,
+    find_washout_period_v3,
+    find_washout_period_v4,
+    find_washout_period_v5,
+)
 
-for label, txt in examples.items():
-    print(f"\n=== {label} ===\n{txt}")
-    for name, fn in WASHOUT_PERIOD_FINDERS.items():
-        print(f" {name}: {fn(txt)}")
+# ─────────────────────────────────────────────
+# Robust Tests for v1 – high recall cues only
+# ─────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("Patients underwent a 4-week washout before randomization.", True, "v1_pos_washout_cue"),
+        ("Subjects completed a run-in period prior to baseline.", True, "v1_pos_runin_cue"),
+        ("Treatment-free intervals were documented.", True, "v1_pos_treatment_free"),
+        ("No therapy was administered during the washout phase.", True, "v1_pos_no_therapy"),
+        ("Cells were washed with PBS before incubation.", False, "v1_neg_lab_context"),
+        ("Drug therapy was discontinued due to side-effects.", False, "v1_neg_side_effect_trap"),
+    ]
+)
+def test_find_washout_period_v1(text, should_match, test_id):
+    matches = find_washout_period_v1(text)
+    assert bool(matches) == should_match, f"v1 failed for ID: {test_id}"
+
+# ─────────────────────────────────────────────
+# Robust Tests for v2 – cue + duration within window
+# ─────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("A 6-week washout period was implemented before baseline.", True, "v2_pos_duration_near_cue"),
+        ("Patients were drug-free for 2 months before index.", True, "v2_pos_drugfree_duration"),
+        ("Run-in lasted 3 weeks prior to treatment.", True, "v2_pos_runin_duration"),
+        ("Participants underwent a washout but no duration was specified.", False, "v2_neg_missing_duration"),
+        ("Drug-free intervals were documented long ago.", False, "v2_neg_distance_too_far"),
+        ("Antihypertensives were stopped due to adverse events.", False, "v2_neg_side_effect_trap"),
+    ]
+)
+def test_find_washout_period_v2(text, should_match, test_id):
+    matches = find_washout_period_v2(text, window=8)
+    assert bool(matches) == should_match, f"v2 failed for ID: {test_id}"
+
+# ─────────────────────────────────────────────
+# Lighter Checks for v3 – heading-based block
+# ─────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("Washout Period:\nSubjects discontinued medication for 4 weeks before index.\n\n", True, "v3_pos_heading_block"),
+        ("Run-in:\nA 6-week drug-free period preceded the intervention.\n\n", True, "v3_pos_runin_block"),
+        ("Clearance period:\nNo antihypertensives were used.\n\n", True, "v3_pos_clearance_block"),
+        ("Methods:\nPatients underwent a 4-week washout before starting the drug.", False, "v3_neg_wrong_heading"),
+        ("Introduction:\nNo therapy was given before treatment.", False, "v3_neg_heading_absent"),
+    ]
+)
+def test_find_washout_period_v3(text, should_match, test_id):
+    matches = find_washout_period_v3(text)
+    assert bool(matches) == should_match, f"v3 failed for ID: {test_id}"
+
+# ─────────────────────────────────────────────
+# Lighter Checks for v4 – cue + duration + BEFORE anchor
+# ─────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("A 3-month drug-free period was required before baseline.", True, "v4_pos_duration_and_before"),
+        ("Patients had a washout phase of 6 weeks prior to randomization.", True, "v4_pos_washout_prior_index"),
+        ("Subjects were treatment-free for 2 months preceding study start.", True, "v4_pos_preceding_start"),
+        ("Run-in occurred for 2 weeks but no timing anchor given.", False, "v4_neg_missing_anchor"),
+        ("Patients stopped due to adverse events before baseline.", False, "v4_neg_trap_side_effect"),
+        ("Washout was described but before/after not mentioned.", False, "v4_neg_no_temporal_anchor"),
+    ]
+)
+def test_find_washout_period_v4(text, should_match, test_id):
+    matches = find_washout_period_v4(text, window=8)
+    assert bool(matches) == should_match, f"v4 failed for ID: {test_id}"
+
+# ─────────────────────────────────────────────
+# Lighter Checks for v5 – tight template match
+# ─────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("A 12-month washout with no antihypertensives was required before index.", True, "v5_pos_pubmed_style_template"),
+        ("Patients were drug-free for 6 months before index.", True, "v5_pos_drugfree_months_template"),
+        ("Subjects completed a 4-week washout with no therapy.", True, "v5_pos_template_with_no_therapy"),
+        ("A washout was done.", False, "v5_neg_no_duration"),
+        ("Washout for 2 months, no comment on timing.", False, "v5_neg_missing_before_index"),
+        ("Patients stopped due to intolerance.", False, "v5_neg_adverse_event_template"),
+    ]
+)
+def test_find_washout_period_v5(text, should_match, test_id):
+    matches = find_washout_period_v5(text)
+    assert bool(matches) == should_match, f"v5 failed for ID: {test_id}"


### PR DESCRIPTION
### Summary
This PR enhances the washout_period_finder.py module by improving Unicode‑hyphen support, expanding cue patterns, and switching proximity logic from character‑based windows to robust token‑distance checks. All existing and new tests in test_washout_period_finder.py continue to pass at 100%.

### Changes

**1. Hyphen & Separator Constants**
- Introduced HYPHEN = r"[-\u2011]" to match normal and non‑breaking hyphens.
- Added SEP = rf"(?:{HYPHEN}|\s+)" to unify hyphen or whitespace separators.

**2. Expanded Cue & Heading Regexes**
- Broadened WASHOUT_CUE_RE to include standalone cues (“washout”), all hyphen/space variants, and new patterns such as no antihypertensives.
- Updated HEADING_WASHOUT_RE to use SEP and match “Washout Period:”, “Run‑in:”, and “Clearance Period:” consistently.

**3. Duration & Anchor Patterns**
- Added NUMBER_WORD regex for spelled‑out numbers (one through twelve).
- Extended DURATION_RE to detect both digits and words (e.g. “six month”).
- Refined BEFORE_ANCHOR_RE to account for hyphens or spaces in “pre‑index” and “pre‑baseline”.
- Introduced _char_to_token_index_map helper to map character positions to token indices.

**4.Refactored Finder Tiers**
- v2 (find_washout_period_v2): Replaced brittle character‑distance check with abs(token_index_cue – token_index_duration) ≤ window.
- v4 (find_washout_period_v4): Same token‑distance logic plus enforcement of BEFORE_ANCHOR_RE within a snippet.
- v3 (find_washout_period_v3): Ensures any cue or duration under matching headings is captured, using the updated regexes and token spans.
- v5 (TIGHT_TEMPLATE_RE): Refined to be more flexible with hyphens, spaces, and varied phrasing in stringent washout templates.