### PR TITLE
feat(finders): add algorithm validation, baseline data, data provenance, med cohort, and settings/locations modules

### DIFF
--- a/src/pyregularexpression/algorithm_validation_finder.py
+++ b/src/pyregularexpression/algorithm_validation_finder.py
@@ -59,10 +59,12 @@ def find_algorithm_validation_v3(text:str, block_chars:int=300):
         blocks.append((s,e))
     inside=lambda p:any(s<=p<e for s,e in blocks)
     out=[]
-    for m in ALGO_TERM_RE.finditer(text):
-        if inside(m.start()):
-            w_s,w_e=_char_span_to_word_span((m.start(),m.end()),token_spans)
-            out.append((w_s,w_e,m.group(0)))
+    for patt in [ALGO_TERM_RE, METRIC_TOKEN_RE]:
+        for m in patt.finditer(text):
+            if inside(m.start()):
+                w_s, w_e = _char_span_to_word_span((m.start(), m.end()), token_spans)
+                out.append((w_s, w_e, m.group(0)))
+
     return out
 
 def find_algorithm_validation_v4(text:str, window:int=6):

--- a/src/pyregularexpression/settings_locations_finder.py
+++ b/src/pyregularexpression/settings_locations_finder.py
@@ -1,10 +1,14 @@
-"""eligibility_criteria_finder.py – precision/recall ladder for *inclusion / exclusion eligibility criteria* statements.
+"""
+settings_locations_finder.py – precision/recall ladder for *study settings / locations* 
+(where the research was conducted, e.g., hospital, clinic, city, country).
+
 Five variants (v1–v5):
-    • v1 – high recall: any eligibility cue (eligible patients were, inclusion criteria included, we excluded participants who, exclusion criteria, criteria for enrollment, eligible if).
-    • v2 – explicit inclusion OR exclusion cue + condition within ±4 tokens (numeric/age/diagnosis etc.).
-    • v3 – only inside an *Eligibility / Inclusion and Exclusion Criteria* heading block (first ~500 characters).
-    • v4 – v2 plus both an inclusion and an exclusion cue in the same sentence/nearby to maximise precision.
-    • v5 – tight template: paired statement listing age/diagnosis eligibility and exclusion of specific conditions (e.g., “Adults 18–65 with diabetes were eligible; prior insulin use was an exclusion”).
+    • v1 – high recall: any clause containing 'setting(s)' or 'conducted/performed/carried out' + location terms.
+    • v2 – v1 **and** explicit facility or geographic term (hospital, clinic, university, school, community, country, city, region).
+    • v3 – only inside a *Study Setting*, *Methods*, or *Participants* heading block (first ~400 characters).
+    • v4 – v2 plus geopolitical or institutional entity (country names, cities, WHO regions, universities) in same sentence.
+    • v5 – tight template: “The study was conducted at [facility] in [city], [country].”
+
 Each finder returns tuples: (start_word_idx, end_word_idx, snippet).
 """
 from __future__ import annotations
@@ -22,85 +26,130 @@ def _char_to_word(span: Tuple[int, int], spans: Sequence[Tuple[int, int]]):
     w_e = next(i for i, (a, b) in reversed(list(enumerate(spans))) if a < e <= b)
     return w_s, w_e
 
-INCL_CUE_RE = re.compile(r"\b(?:eligible\s+(?:patients|participants|subjects|individuals)\s+were|inclusion\s+criteria\s+(?:included|were|consisted\s+of)|eligible\s+if|criteria\s+for\s+enrollment|patients?\s+were\s+eligible|we\s+included|must\s+meet\s+all\s+of\s+the\s+following|required\s+to\s+have)\b", re.I)
-EXCL_CUE_RE = re.compile(r"\b(?:we\s+excluded|exclusion\s+criteria|excluded\s+patients?|patients?\s+were\s+excluded|exclusion\s+included|were\s+not\s+eligible|must\s+not\s+have)\b", re.I)
-ELIG_CUE_RE = re.compile(r"\b(?:inclusion\s+criteria|exclusion\s+criteria|eligible|enrollment\s+criteria)\b", re.I)
-HEADING_ELIG_RE = re.compile(r"(?m)^(?:eligibility|inclusion\s+and\s+exclusion\s+criteria|study\s+population|participants?)\s*[:\-]?\s*$", re.I)
-TRAP_RE = re.compile(r"\b(?:diagnostic\s+criteria|classification\s+criteria|performance\s+criteria)\b", re.I)
-TIGHT_TEMPLATE_RE = re.compile(
-    r"\b(?:adults?|children)\s+\d{1,3}(?:–|-|\s+to\s+)\d{1,3}\s+[^\.\n]{0,80}(?:eligible|inclusion\s+criteria)[^\.\n]{0,120}(?:exclusion\s+criteria|were\s+excluded)\b",
-    re.I,
+# --- Regex patterns ---
+SETTING_RE = re.compile(r"\bsettings?\b", re.I)
+CONDUCT_RE = re.compile(r"\b(?:conducted|performed|carried\s+out|undertaken)\b", re.I)
+
+FACILITY_RE = re.compile(
+    r"\b(?:hospital(?:s)?|clinic(?:s)?|centre(?:s)?|center(?:s)?|university(?:ies)?|school(?:s)?|practice(?:s)?|"
+    r"ward(?:s)?|laborator(?:y|ies)|community|communities)\b",
+    re.I
 )
 
+GEO_RE = re.compile(
+    r"\b(?:USA|United\s+States|UK|United\s+Kingdom|India|China|Canada|Australia|Europe|Asia|Africa|"
+    r"France|Germany|Italy|Spain|Brazil|Mexico|Japan|Korea|Russia|Nigeria|South\s+Africa|"
+    r"city|country|region)\b\.?",
+    re.I
+)
+
+HEAD_SEC_RE = re.compile(r"(?i)(study\s+setting|methods?|participants?)\s*[:\-]?", re.M)
+
+TIGHT_TEMPLATE_RE = re.compile(
+    r"(?:the\s+study\s+was\s+(?:conducted|performed|carried\s+out)\s+at\s+.+?\s+(?:hospital|clinic|university|school)\s+in\s+[A-Z][a-z]+(?:,\s*[A-Z][a-z]+)*)",
+    re.I
+)
+
+CUE_RE = re.compile(
+    r"\b(?:conducted|performed|carried\s+out|undertaken|recruited|obtained|collected)\b",
+    re.I
+)
+
+# --- Helper to collect matches ---
 def _collect(patterns: Sequence[re.Pattern[str]], text: str):
     spans = _token_spans(text)
-    out = []
+    out: List[Tuple[int, int, str]] = []
     for patt in patterns:
         for m in patt.finditer(text):
-            if TRAP_RE.search(text[max(0, m.start()-25):m.end()+25]):
-                continue
             w_s, w_e = _char_to_word((m.start(), m.end()), spans)
             out.append((w_s, w_e, m.group(0)))
     return out
 
-def find_eligibility_criteria_v1(text: str):
-    return _collect([INCL_CUE_RE, EXCL_CUE_RE, ELIG_CUE_RE], text)
+# Variant 1 – High recall: mentions of "settings" or "conducted" phrases
+def find_settings_location_v1(text: str):
+    pattern = re.compile(
+        r"(?:study\s+settings?|research\s+setting|study\s+was\s+(?:conducted|performed|carried\s+out|undertaken))",
+        re.I
+    )
+    matches = _collect([pattern], text)
+    filtered = []
+    for w_s, w_e, snippet in matches:
+        span_text = text.lower()
+        start_char = snippet.lower()
+        before = " ".join(text.split()[:w_s][-5:]).lower()
+        if ("without reference to" in before or 
+            before.endswith("no") or 
+            before.endswith("without")):
+            continue
+        filtered.append((w_s, w_e, snippet))
+    return filtered
 
-def find_eligibility_criteria_v2(text: str, window: int = 4):
-    qualifier_re = re.compile(r"\b(age\s+\d{1,3}|\d{1,3}\s*(?:years?|yrs?)|male|female|men|women|diagnosed|history\s+of)\b", re.I)
+# Variant 2 – Add facility term requirement
+def find_settings_location_v2(text: str, window: int = 5):
     spans = _token_spans(text)
     tokens = [text[s:e] for s, e in spans]
-    qual_idx = {i for i, t in enumerate(tokens) if qualifier_re.fullmatch(t)}
-    cue_idx = {i for i, t in enumerate(tokens) if INCL_CUE_RE.fullmatch(t) or EXCL_CUE_RE.fullmatch(t)}
+    loc_idx = {i for i, t in enumerate(tokens) if CUE_RE.search(t)}
+    fac_idx = {i for i, t in enumerate(tokens) if FACILITY_RE.search(t)}
     out = []
-    for i in cue_idx:
-        if any(q for q in qual_idx if abs(q - i) <= window):
-            w_s, w_e = _char_to_word(spans[i], spans)
-            out.append((w_s, w_e, tokens[i]))
+    for li in loc_idx:
+        if any(abs(fi - li) <= window for fi in fac_idx):
+            w_s = max(0, li - window)
+            w_e = min(len(tokens)-1, li + window)
+            snippet = " ".join(tokens[w_s:w_e+1])
+            out.append((w_s, w_e, snippet))
     return out
 
-def find_eligibility_criteria_v3(text: str, block_chars: int = 500):
+# Variant 3 – Restrict to Study Setting/Methods/Participants blocks
+def find_settings_location_v3(text: str, block_chars: int = 400):
     spans = _token_spans(text)
     blocks = []
-    for h in HEADING_ELIG_RE.finditer(text):
+    for h in HEAD_SEC_RE.finditer(text):
         s = h.end(); e = min(len(text), s + block_chars)
         blocks.append((s, e))
     inside = lambda p: any(s <= p < e for s, e in blocks)
     out = []
-    for m in (INCL_CUE_RE, EXCL_CUE_RE):
-        for x in m.finditer(text):
-            if inside(x.start()):
-                w_s, w_e = _char_to_word((x.start(), x.end()), spans)
-                out.append((w_s, w_e, x.group(0)))
+    for m in FACILITY_RE.finditer(text):
+        if inside(m.start()):
+            w_s, w_e = _char_to_word((m.start(), m.end()), spans)
+            out.append((w_s, w_e, m.group(0)))
     return out
 
-def find_eligibility_criteria_v4(text: str, window: int = 6):
-    spans = _token_spans(text)
-    tokens = [text[s:e] for s, e in spans]
-    incl_idx = {i for i, t in enumerate(tokens) if INCL_CUE_RE.fullmatch(t)}
-    excl_idx = {i for i, t in enumerate(tokens) if EXCL_CUE_RE.fullmatch(t)}
+# Variant 4 – Facility + geopolitical/geographic terms
+def find_settings_location_v4(text: str, window: int = 8):
+    base_matches = find_settings_location_v2(text, window=window)
+    if not base_matches:
+        return []
+    sentences = re.split(r'(?<=[.!?])\s+', text)
     out = []
-    for i in incl_idx:
-        if any(e for e in excl_idx if abs(e - i) <= window):
-            w_s, w_e = _char_to_word(spans[i], spans)
-            out.append((w_s, w_e, tokens[i]))
+    for w_s, w_e, snip in base_matches:
+        for sent in sentences:
+            if snip in sent:
+                if GEO_RE.search(sent):
+                    out.append((w_s, w_e, snip))
+                break
     return out
 
-def find_eligibility_criteria_v5(text: str):
+# Variant 5 – Tight template form
+def find_settings_location_v5(text: str):
     return _collect([TIGHT_TEMPLATE_RE], text)
 
-ELIGIBILITY_CRITERIA_FINDERS: Dict[str, Callable[[str], List[Tuple[int,int,str]]]] = {
-    "v1": find_eligibility_criteria_v1,
-    "v2": find_eligibility_criteria_v2,
-    "v3": find_eligibility_criteria_v3,
-    "v4": find_eligibility_criteria_v4,
-    "v5": find_eligibility_criteria_v5,
+# --- Registry ---
+SETTINGS_LOCATION_FINDERS: Dict[str, Callable[[str], List[Tuple[int,int,str]]]] = {
+    "v1": find_settings_location_v1,
+    "v2": find_settings_location_v2,
+    "v3": find_settings_location_v3,
+    "v4": find_settings_location_v4,
+    "v5": find_settings_location_v5,
 }
 
 __all__ = [
-    "find_eligibility_criteria_v1", "find_eligibility_criteria_v2", "find_eligibility_criteria_v3",
-    "find_eligibility_criteria_v4", "find_eligibility_criteria_v5", "ELIGIBILITY_CRITERIA_FINDERS",
+    "find_settings_location_v1",
+    "find_settings_location_v2",
+    "find_settings_location_v3",
+    "find_settings_location_v4",
+    "find_settings_location_v5",
+    "SETTINGS_LOCATION_FINDERS",
 ]
 
-find_eligibility_criteria_high_recall = find_eligibility_criteria_v1
-find_eligibility_criteria_high_precision = find_eligibility_criteria_v5
+find_settings_location_high_recall = find_settings_location_v1
+find_settings_location_high_precision = find_settings_location_v5

--- a/tests/test_algorithm_validation_finder.py
+++ b/tests/test_algorithm_validation_finder.py
@@ -1,15 +1,121 @@
+"""
+Complete test suite for algorithm_validation_finder.py.
 
-"""Smoke tests for algorithm_validation_finder variants."""
-from pyregularexpression.algorithm_validation_finder import ALGORITHM_VALIDATION_FINDERS
+Includes:
+- Robust tests for v1 and v2 (recall and context awareness)
+- Lighter representative tests for v3, v4, and v5
+- All examples inspired by real OHDSI or PubMed validation literature
+"""
 
-examples = {
-    "hit_metric": "Algorithm was validated against chart review; PPV 92 % and sensitivity 88 %.",
-    "hit_accuracy": "Accuracy 0.89 (95 % CI) was achieved in external validation of the algorithm.",
-    "miss_use": "We applied the algorithm to identify diabetic patients.",
-    "miss_assay": "Assay sensitivity was 98 %."
-}
+import pytest
+from pyregularexpression.algorithm_validation_finder import (
+    find_algorithm_validation_v1,
+    find_algorithm_validation_v2,
+    find_algorithm_validation_v3,
+    find_algorithm_validation_v4,
+    find_algorithm_validation_v5,
+)
 
-for label, txt in examples.items():
-    print(f"\n=== {label} ===\n{txt}")
-    for name, fn in ALGORITHM_VALIDATION_FINDERS.items():
-        print(f" {name}: {fn(txt)}")
+# ─────────────────────────────
+# Robust Tests for v1 – High Recall
+# ─────────────────────────────
+
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        # Positive examples
+        ("Algorithm validation was performed using chart review.", True, "v1_pos_algorithm_validation_phrase"),
+        ("We assessed algorithm performance in identifying atrial fibrillation.", True, "v1_pos_validated_with_performance"),
+        ("The sensitivity and PPV of the algorithm were evaluated.", True, "v1_pos_metric_keyword"),
+        
+        # Trap phrases (must not match)
+        ("A validated questionnaire was used to assess symptoms.", False, "v1_trap_validated_questionnaire"),
+        ("Analytical method validation showed acceptable results.", False, "v1_trap_method_validation"),
+        
+        # Negative examples
+        ("The algorithm was applied to detect heart failure.", False, "v1_neg_applied_no_validation"),
+        ("Our method uses rule-based logic.", False, "v1_neg_generic_method"),
+    ]
+)
+def test_find_algorithm_validation_v1(text, should_match, test_id):
+    matches = find_algorithm_validation_v1(text)
+    assert bool(matches) == should_match, f"v1 failed for ID: {test_id}"
+
+
+# ─────────────────────────────
+# Robust Tests for v2 – Windowed Context: algorithm + validation verb
+# ─────────────────────────────
+
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        # Positive examples
+        ("The algorithm was externally validated on a claims database.", True, "v2_pos_algorithm_validated_near"),
+        ("We evaluated the algorithm’s performance using test data.", True, "v2_pos_evaluated_algorithm_near"),
+        
+        # Negative examples
+        ("Validated instrument used to collect survey data.", False, "v2_neg_trap_validated_instrument"),
+        ("The cohort was defined using a known algorithm.", False, "v2_neg_no_validation_verb"),
+    ]
+)
+def test_find_algorithm_validation_v2(text, should_match, test_id):
+    matches = find_algorithm_validation_v2(text)
+    assert bool(matches) == should_match, f"v2 failed for ID: {test_id}"
+
+
+# ─────────────────────────────
+# Lighter Tests for v3 – Inside validation/performance heading blocks
+# ─────────────────────────────
+
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("Algorithm validation:\nThe algorithm was evaluated on EHR data.\n\n", True, "v3_pos_in_heading_block"),
+        ("Performance evaluation:\nAccuracy and PPV were calculated.\n\n", True, "v3_pos_metric_in_heading_block"),
+        ("Results:\nThe algorithm showed good performance.\n\n", False, "v3_neg_wrong_heading"),
+    ]
+)
+def test_find_algorithm_validation_v3(text, should_match, test_id):
+    matches = find_algorithm_validation_v3(text)
+    assert bool(matches) == should_match, f"v3 failed for ID: {test_id}"
+
+
+# ─────────────────────────────
+# Lighter Tests for v4 – v2 + metric keyword in window
+# ─────────────────────────────
+
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        # Positive: v2 + metric
+        ("The algorithm was evaluated and achieved a PPV of 91%.", True, "v4_pos_eval_metric_combo"),
+        
+        # Negative: v2 match without metric
+        ("We evaluated the algorithm for use in identifying asthma.", False, "v4_neg_no_metric_near"),
+        ("Validated by comparing diagnoses with physician notes.", False, "v4_neg_no_metric_trap_like"),
+    ]
+)
+def test_find_algorithm_validation_v4(text, should_match, test_id):
+    matches = find_algorithm_validation_v4(text)
+    assert bool(matches) == should_match, f"v4 failed for ID: {test_id}"
+
+
+# ─────────────────────────────
+# Lighter Tests for v5 – Tight template match
+# ─────────────────────────────
+
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        # Positive: realistic template
+        ("Algorithm was validated using chart review; PPV 91% and sensitivity 88%.", True, "v5_pos_chart_review_ppv"),
+        ("The algorithm was validated in external data with accuracy 0.89 (95% CI).", True, "v5_pos_accuracy_with_algorithm"),
+        
+        # Negative: loose structure
+        ("The algorithm was applied to identify cases; results were promising.", False, "v5_neg_applied_loose"),
+        ("Validation included review of patient cases but no metrics reported.", False, "v5_neg_no_metric"),
+    ]
+)
+def test_find_algorithm_validation_v5(text, should_match, test_id):
+    matches = find_algorithm_validation_v5(text)
+    assert bool(matches) == should_match, f"v5 failed for ID: {test_id}"

--- a/tests/test_baseline_data_finder.py
+++ b/tests/test_baseline_data_finder.py
@@ -1,14 +1,117 @@
-"""Smoke tests for baseline_data_finder."""
-from pyregularexpression.baseline_data_finder import BASELINE_DATA_FINDERS
+#tests/test_baseline_data_finder.py
 
-examples = {
-    "hit_vs": "Baseline characteristics: Mean age 54 vs 55, 60 % female in both groups.",
-    "hit_table": "Table 1 lists baseline demographics with BMI 28.5 ± 4.2 and 45% smokers.",
-    "miss_single": "Baseline tumor size recorded for each patient.",
-    "miss_nocue": "Patients had similar age distributions."
-}
+import pytest
+from pyregularexpression.baseline_data_finder import (
+    find_baseline_data_v1,
+    find_baseline_data_v2,
+    find_baseline_data_v3,
+    find_baseline_data_v4,
+    find_baseline_data_v5,
+)
 
-for label, txt in examples.items():
-    print(f"\n=== {label} ===\n{txt}")
-    for name, fn in BASELINE_DATA_FINDERS.items():
-        print(f" {name}: {fn(txt)}")
+# ─────────────────────────────
+# Robust Tests for v1 – High Recall: baseline cue + number/%
+# ─────────────────────────────
+
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        # Positive examples
+        ("Baseline characteristics: Mean age 63 years, 45% male.", True, "v1_pos_age_pct"),
+        ("At baseline, BMI was 27.5 ± 4.1.", True, "v1_pos_at_baseline_numeric"),
+        ("Table 1 shows demographics including 30% smokers.", True, "v1_pos_table_with_percentage"),
+
+        # Negative examples
+        ("Baseline tumor location was recorded.", False, "v1_neg_no_number"),
+        ("Participants were enrolled from multiple centers.", False, "v1_neg_no_baseline_cue"),
+        ("The majority were male.", False, "v1_neg_no_baseline_or_number"),
+    ]
+)
+def test_find_baseline_data_v1(text, should_match, test_id):
+    matches = find_baseline_data_v1(text)
+    assert bool(matches) == should_match, f"v1 failed for ID: {test_id}"
+
+
+# ─────────────────────────────
+# Robust Tests for v2 – v1 + group comparison cue (e.g., vs, placebo)
+# ─────────────────────────────
+
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        # Positive examples
+        ("Mean age at baseline was 54 vs 55 years in treatment and placebo groups.", True, "v2_pos_vs_with_groups"),
+        ("Table 1: 60% female in the treatment group, 58% in placebo.", True, "v2_pos_group_labels"),
+        ("Baseline BMI was 29.4 ± 5.1 compared to 27.1 ± 4.9.", True, "v2_pos_compared_to"),
+
+        # Negative examples
+        ("Baseline BMI was 27.3 for the entire cohort.", False, "v2_neg_no_group_comparison"),
+        ("Baseline characteristics: Mean age 63.", False, "v2_neg_number_but_no_group_term"),
+    ]
+)
+def test_find_baseline_data_v2(text, should_match, test_id):
+    matches = find_baseline_data_v2(text)
+    assert bool(matches) == should_match, f"v2 failed for ID: {test_id}"
+
+
+# ─────────────────────────────
+# Lighter Tests for v3 – In heading blocks (Baseline Characteristics / Table 1)
+# ─────────────────────────────
+
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        # Positive examples
+        ("Baseline Characteristics:\nMean age 56 years, BMI 28.4 ± 3.7\n\n", True, "v3_pos_heading_block"),
+        ("Table 1\nDemographics: 49% female and 31% smokers.\n\n", True, "v3_pos_table_heading"),
+
+        # Negative examples
+        ("Demographics summary: age 54, 60% male.", False, "v3_neg_wrong_heading"),
+        ("Patient characteristics:\nSmoking status was reported.", False, "v3_neg_not_in_baseline_block"),
+    ]
+)
+def test_find_baseline_data_v3(text, should_match, test_id):
+    matches = find_baseline_data_v3(text)
+    assert bool(matches) == should_match, f"v3 failed for ID: {test_id}"
+
+
+# ─────────────────────────────
+# Lighter Tests for v4 – v2 + ≥2 variables or multiple numeric values
+# ─────────────────────────────
+
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        # Positive examples
+        ("At baseline: age 55 vs 57, BMI 29.3 vs 27.4.", True, "v4_pos_multiple_variables"),
+        ("Baseline characteristics: 63% male vs 60%, mean age 54 vs 55.", True, "v4_pos_pct_and_age"),
+        ("Baseline: BMI 29.4 in treatment vs 28.7 placebo.", True, "v4_pos_two_numbers_one_var"),
+
+        # Negative examples
+        ("At baseline, heart rate was measured.", False, "v4_neg_no_group_no_multiple_numbers"),
+    ]
+)
+def test_find_baseline_data_v4(text, should_match, test_id):
+    matches = find_baseline_data_v4(text)
+    assert bool(matches) == should_match, f"v4 failed for ID: {test_id}"
+
+
+# ─────────────────────────────
+# Lighter Tests for v5 – Tight template match
+# ─────────────────────────────
+
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        # Positive examples
+        ("Mean age 54 vs 55; 60 % female in both groups at baseline.", True, "v5_pos_mean_age_pct_both_groups"),
+        ("Baseline: 70% male vs 68% male; median age 52 vs 50.", True, "v5_pos_compact_template"),
+
+        # Negative examples
+        ("Baseline BMI 28.5 in treatment and 28.3 in placebo.", False, "v5_neg_not_enough_structure"),
+        ("At baseline: mean age 54; no gender data reported.", False, "v5_neg_missing_comparison_structure"),
+    ]
+)
+def test_find_baseline_data_v5(text, should_match, test_id):
+    matches = find_baseline_data_v5(text)
+    assert bool(matches) == should_match, f"v5 failed for ID: {test_id}"

--- a/tests/test_med_cohort.py
+++ b/tests/test_med_cohort.py
@@ -1,7 +1,7 @@
 # tests/test_med_cohort.py
 import re
 import pytest
-from pyregularexpression import (
+from pyregularexpression.med_cohort import (
     extract_medical_codes,
     find_cohort_logic,
     MEDICAL_CODE_RE,

--- a/tests/test_settings_locations_finder.py
+++ b/tests/test_settings_locations_finder.py
@@ -1,14 +1,101 @@
-"""Smoke tests for eligibility_criteria_finder variants."""
-from pyregularexpression.eligibility_criteria_finder import ELIGIBILITY_CRITERIA_FINDERS
+# tests/test_settings_locations_finder.py
+"""
+Pytest suite for settings_locations_finder.py
+Ladder v1–v5:
+    • v1 – any “setting(s)” mention or “study was conducted” cue
+    • v2 – v1 + explicit facility (hospital, clinic, university, community, etc.)
+    • v3 – only inside Study Setting / Methods / Participants heading block
+    • v4 – v2 + explicit geographic entity (city, country, region)
+    • v5 – tight template: “The study was conducted at [facility] in [city], [country]”
+"""
+import pytest
+from pyregularexpression.settings_locations_finder import (
+    find_settings_location_v1,
+    find_settings_location_v2,
+    find_settings_location_v3,
+    find_settings_location_v4,
+    find_settings_location_v5,
+)
 
-examples = {
-    "hit_combo": "Adults 18–65 with diabetes were eligible; prior insulin use was an exclusion criterion.",
-    "hit_incl": "Eligible patients were required to be male and diagnosed with COPD.",
-    "miss_diag": "We applied standard diagnostic criteria to confirm diabetes.",
-    "miss_analysis": "Eligible datasets were included in the analysis."
-}
+# ─────────────────────────────
+# v1 – high recall
+# ─────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("Study settings included primary care practices across three regions.", True, "v1_pos_settings"),
+        ("The study was conducted among participants recruited online.", True, "v1_pos_conducted"),
+        ("Outcomes were reported without reference to study setting.", False, "v1_neg_no_setting"),
+        ("The research setting was a large metropolitan area.", True, "v1_pos_research_setting"),
+        ("No mention of hospitals or study conduct is made here.", False, "v1_neg_no_cue"),
+    ],
+)
+def test_v1_settings_location(text, should_match, test_id):
+    matches = find_settings_location_v1(text)
+    assert bool(matches) == should_match, f"v1 failed for {test_id}"
 
-for label, txt in examples.items():
-    print(f"\n=== {label} ===\n{txt}")
-    for name, fn in ELIGIBILITY_CRITERIA_FINDERS.items():
-        print(f" {name}: {fn(txt)}")
+
+# ─────────────────────────────
+# v2 – add facility term
+# ─────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("The study was conducted at a tertiary hospital.", True, "v2_pos_hospital"),
+        ("Participants were recruited from community clinics.", True, "v2_pos_clinic"),
+        ("The study was conducted in 2019 with no facility named.", False, "v2_neg_no_facility"),
+        ("Conducted at the University Medical Center.", True, "v2_pos_university_medical_center"),
+        ("The investigation was carried out nationwide without specific sites.", False, "v2_neg_no_facility_word"),
+    ],
+)
+def test_v2_settings_location(text, should_match, test_id):
+    matches = find_settings_location_v2(text, window=5)
+    assert bool(matches) == should_match, f"v2 failed for {test_id}"
+
+
+# ─────────────────────────────
+# v3 – only inside Study Setting / Methods / Participants blocks
+# ─────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("Study Setting:\nPatients were enrolled at a university hospital.", True, "v3_pos_setting_block"),
+        ("Methods:\nData were collected from rural community clinics.", True, "v3_pos_methods_block"),
+        ("Discussion:\nOur findings may not generalize to all populations.", False, "v3_neg_discussion"),
+    ],
+)
+def test_v3_settings_location(text, should_match, test_id):
+    matches = find_settings_location_v3(text)
+    assert bool(matches) == should_match, f"v3 failed for {test_id}"
+
+
+# ─────────────────────────────
+# v4 – facility + geographic entity
+# ─────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("The study was conducted at a teaching hospital in New York, USA.", True, "v4_pos_hospital_city_country"),
+        ("Data were obtained from primary care clinics in rural India.", True, "v4_pos_clinics_country"),
+        ("The study was conducted at a clinic, but no geographic location provided.", False, "v4_neg_no_geo"),
+    ],
+)
+def test_v4_settings_location(text, should_match, test_id):
+    matches = find_settings_location_v4(text, window=8)
+    assert bool(matches) == should_match, f"v4 failed for {test_id}"
+
+
+# ─────────────────────────────
+# v5 – tight template
+# ─────────────────────────────
+@pytest.mark.parametrize(
+    "text, should_match, test_id",
+    [
+        ("The study was conducted at the University Hospital in Paris, France.", True, "v5_pos_university_hospital"),
+        ("The study was performed at a community clinic in Mumbai, India.", True, "v5_pos_clinic_city_country"),
+        ("Settings: patients were enrolled at hospitals and clinics worldwide.", False, "v5_neg_general"),
+    ],
+)
+def test_v5_settings_location(text, should_match, test_id):
+    matches = find_settings_location_v5(text)
+    assert bool(matches) == should_match, f"v5 failed for {test_id}"


### PR DESCRIPTION
### Summary
This PR introduces additional finder modules to extend metadata extraction capabilities across trial methodology and reporting.

### Added / Updated Modules
- **algorithm_validation_finder**
- **baseline_data_finder**
- **data_provenance_finder**
- **med_cohort**
- **settings_locations_finder**

### Tests
- Added corresponding unit tests in the `tests/` directory.
- Verified functionality using `pytest -vv` — all tests passing.

### Notes
- Complements earlier modules from `Sudeep8` and `Sudeep9`.
- Extends coverage of trial design and reporting metadata for downstream validation.
