### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Collection of reusable regular‑expression patterns"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [{ name = "Gowtham Rao", email = "rao@ohdsi.org" }]
 keywords = ["regex", "regular expressions", "patterns"]
 classifiers = [


### PR DESCRIPTION
This commit drops support for Python 3.9 to resolve test failures caused by the use of the `slots` argument in dataclasses, which is only available in Python 3.10 and later.

The following changes were made:
- The GitHub Actions workflow in `.github/workflows/python-tests.yml` has been updated to remove Python 3.9 from the test matrix.
- The `pyproject.toml` file has been updated to set the minimum required Python version to 3.10.