### PR TITLE
Make package ready for PyPI submission

### DIFF
--- a/src/pyregularexpression/__init__.py
+++ b/src/pyregularexpression/__init__.py
@@ -34,8 +34,13 @@ __all__: List[str] = []
 for _finder, _mod_name, _is_pkg in pkgutil.iter_modules(__path__):
     if _mod_name.startswith("_"):
         continue  # skip private helpers like _version.py
+    try:
+        _module: ModuleType = importlib.import_module(f".{_mod_name}", __name__)
+    except ModuleNotFoundError as e:
+        if e.name == "pyspark":
+            continue
+        raise
 
-    _module: ModuleType = importlib.import_module(f".{_mod_name}", __name__)
     _exports = getattr(_module, "__all__", None)
 
     if _exports is None:  # fall back to “everything that isn’t private”

--- a/tests/test_extract_regex_paragraphs_udf.py
+++ b/tests/test_extract_regex_paragraphs_udf.py
@@ -1,4 +1,5 @@
 import pytest
+pyspark = pytest.importorskip("pyspark")
 import pandas as pd
 import re
 from typing import Callable, List, Tuple


### PR DESCRIPTION
This change addresses an issue where the package would fail to import if the optional `pyspark` dependency was not installed.

The `src/pyregularexpression/__init__.py` file has been modified to wrap the dynamic import of modules in a `try...except ModuleNotFoundError` block. This allows the package to be imported even if `pyspark` is not present.

The tests for the spark functionality in `tests/test_extract_regex_paragraphs_udf.py` have been updated to use `pytest.importorskip("pyspark")`, so they are skipped when `pyspark` is not installed.